### PR TITLE
Fix Streamlit ingestion connectivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ root/data/raw/
 prep/
 models/
 .models/
+!src/core/models/
+!src/core/models/**
 qdrant_data/
 qdrant_data/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       - QDRANT_URL=${QDRANT_URL:-https://your-qdrant-instance.cloud}
       - QDRANT_API_KEY=${QDRANT_API_KEY:-your-api-key}
+      - ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8000,http://sentio-ui:8501,http://localhost:8501
     volumes:
       - ./src:/app/src
       - ./.fallback_cache:/app/.fallback_cache
@@ -31,6 +32,13 @@ services:
       - "8502:8501"
     environment:
       - SENTIO_BACKEND_URL=http://sentio-api:8000
-    command: bash -c "pip install -r /app/requirements.txt && pip install streamlit PyPDF2 && streamlit run src/ui/streamlit_app.py --server.port 8501 --server.address 0.0.0.0"
+    command: >
+      bash -c "apt-get update && apt-get install -y curl && \
+      pip install -r /app/requirements.txt && pip install streamlit PyPDF2 && \
+      streamlit run src/ui/streamlit_app.py --server.port 8501 --server.address 0.0.0.0"
     depends_on:
-      - api 
+      - api
+
+networks:
+  default:
+    driver: bridge

--- a/src/core/ingest/ingest.py
+++ b/src/core/ingest/ingest.py
@@ -359,6 +359,7 @@ class DocumentIngestor:
 
             # Store using async vector store method
             if hasattr(self.vector_store, "add_embeddings"):
+                logger.debug("Storing chunk IDs: %s", ids)
                 await self.vector_store.add_embeddings(
                     texts=texts,
                     embeddings=chunk_embeddings,

--- a/src/core/models/__init__.py
+++ b/src/core/models/__init__.py
@@ -1,0 +1,3 @@
+from .document import Document
+
+__all__ = ["Document"]

--- a/src/core/models/document.py
+++ b/src/core/models/document.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+import uuid
+
+
+@dataclass
+class Document:
+    """Lightweight container for text snippets and associated metadata.
+
+    Attributes:
+        text: The textual content of the document or chunk.
+        metadata: Arbitrary key/value metadata for downstream processors.
+        id: Stable unique identifier generated if not supplied.
+    """
+
+    text: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))


### PR DESCRIPTION
## Summary
- add backend URL fallback and better error handling in Streamlit UI
- relax CSRF for Streamlit origins and log embed requests
- install curl in Streamlit container and expose ALLOWED_ORIGINS
- provide internal `Document` model and version control `src/core/models`

## Testing
- `PYTHONPATH=src pytest` *(fails: assert 403 == 422 ...)*


------
https://chatgpt.com/codex/tasks/task_e_68931eef9ffc83249eb7773f8ad3cd75